### PR TITLE
Use Object#singleton_methods

### DIFF
--- a/lib/flexmock/partial_mock.rb
+++ b/lib/flexmock/partial_mock.rb
@@ -197,7 +197,7 @@ class FlexMock
     # Is the given method name a singleton method in the object we are
     # mocking?
     def singleton?(method_name)
-      @obj.methods(false).include?(method_name.to_s)
+      @obj.singleton_methods.include?(method_name.to_s)
     end
 
     # Hide the existing method definition with a singleton defintion

--- a/test/partial_mock_test.rb
+++ b/test/partial_mock_test.rb
@@ -263,7 +263,24 @@ class TestStubbing < Test::Unit::TestCase
       assert ! dog.respond_to?(sym), "should not have :#{sym} defined"
     end
   end
-
+  
+  # This test ensures that singleton? does not use the old methods(false)
+  # call that has fallen out of favor in Ruby 1.9. In multiple 1.9 releases
+  # Delegator#methods will not even accept the optional argument, making flexmock
+  # explode. Since there is a way to get singleton methods officially we might
+  # as well just do it, right?
+  class NoMethods
+    def methods(arg = true)
+      raise "Should not be called in the test lifecycle"
+    end
+  end
+  
+  def test_object_methods_method_is_not_used_in_singleton_checks
+    obj = NoMethods.new
+    def obj.mock() :original end
+    assert_nothing_raised {  flexmock(obj) }
+  end
+  
   def test_partial_mocks_with_mock_method_singleton_colision_have_original_defs_restored
     dog = Dog.new
     def dog.mock() :original end


### PR DESCRIPTION
In 1.9 multiple versions of Delegator do not accept the extra argument for Object#methods, and Object#methods is not listed in the documentation for Ruby 1.9. Even though it does work we cannot hope it will be available forever. Since there is a published way to get singleton methods and it's backwards compatible it might be a good idea to just use that.
