### PR TITLE
Remove 1.9 specific hash declaration

### DIFF
--- a/lib/flexmock/core.rb
+++ b/lib/flexmock/core.rb
@@ -136,7 +136,7 @@ class FlexMock
 
   def flexmock_based_on(base_class)
     @base_class = base_class
-    should_receive(class: base_class)
+    should_receive(:class => base_class)
   end
 
   # True if the mock received the given method and arguments.


### PR DESCRIPTION
The presence of this one 1.9 specific hash declaration prevents flexmock from being used with older Rubies.
