### PR TITLE
In certain circumstances flexmock breaks rake tasks

### DIFF
--- a/lib/flexmock/test_unit_integration.rb
+++ b/lib/flexmock/test_unit_integration.rb
@@ -9,7 +9,7 @@
 # above copyright notice is included.
 #+++
 
-require 'test/unit'
+require 'test/unit/assertions'
 require 'flexmock/base'
 require 'flexmock/test_unit_assert_spy_called'
 


### PR DESCRIPTION
Happens with ruby 1.9.3 with `Test::Unit`.

Similar problem is described here for `shoulda` gem:
https://github.com/thoughtbot/shoulda/issues/223

Requiring `test/unit/assertions` instead of `test/unit` seems to fix it.
